### PR TITLE
3-B Convertendo a string 123.45 em um número

### DIFF
--- a/3B-Kauã-Filipy.js
+++ b/3B-Kauã-Filipy.js
@@ -1,0 +1,4 @@
+const texto = "123.45"; //Declarando a String
+const numero = parseFloat(texto); //Passando a String para Numero
+console.log(numero); //Exibindo no Console para Numero
+console.log(typeof numero);  //Exibindo no console o tipo primitivo do valor armazenado na variável


### PR DESCRIPTION
## Objetivo

b) Converter a string "123.45" em um número.

## O que foi feito

- Declarei a constante `texto` contendo a string "123.45".
- Usei `parseFloat()` para converter a string em número decimal.
- Exibi no console o número convertido.
- Exibi o tipo primitivo do valor convertido para validar a conversão.